### PR TITLE
Configurable MQTT package size in Controller.ino

### DIFF
--- a/src/Controller.ino
+++ b/src/Controller.ino
@@ -112,7 +112,7 @@ void callback(char *c_topic, byte *b_payload, unsigned int length) {
     return;
   }
 
-  if (length > 384)
+  if (length > MQTT_MAX_PACKET_SIZE)
   {
     addLog(LOG_LEVEL_ERROR, F("MQTT : Ignored too big message"));
     return;


### PR DESCRIPTION
A problem was found with Domoticz MQTT testing, when sending heatpumpir commands via Domoticz MQTT api. MQTT_MAX_PACKET_SIZE is already a setting in platformio.ini